### PR TITLE
Edit du lien pour l'iso debian lien pour 10.6.0 mort

### DIFF
--- a/00_requirements.sh
+++ b/00_requirements.sh
@@ -13,5 +13,5 @@ cd -
 
 # Download Debian iso
 cd packer/ISO
-wget https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.6.0-amd64-netinst.iso
+wget https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.7.0-amd64-netinst.iso
 cd -

--- a/packer/template-debian10--dfir/debian10.json
+++ b/packer/template-debian10--dfir/debian10.json
@@ -27,8 +27,8 @@
       "format": "ova",
       "output_directory": "../ova/",
 
-      "iso_url": "../ISO/debian-10.6.0-amd64-netinst.iso",
-      "iso_checksum": "md5:42c43392d108ed8957083843392c794b",
+      "iso_url": "../ISO/debian-10.7.0-amd64-netinst.iso",
+      "iso_checksum": "md5:7227c779619e6c8a0a1b0f55d10c6270",
       "boot_wait": "5s",
       "boot_command": [
         "<esc><wait>",

--- a/packer/template-debian10--elk/debian10.json
+++ b/packer/template-debian10--elk/debian10.json
@@ -27,8 +27,8 @@
       "format": "ova",
       "output_directory": "../ova/",
 
-      "iso_url": "../ISO/debian-10.6.0-amd64-netinst.iso",
-      "iso_checksum": "md5:42c43392d108ed8957083843392c794b",
+      "iso_url": "../ISO/debian-10.7.0-amd64-netinst.iso",
+      "iso_checksum": "md5:7227c779619e6c8a0a1b0f55d10c6270",
       "boot_wait": "5s",
       "boot_command": [
         "<esc><wait>",

--- a/packer/template-debian10--storage/debian10.json
+++ b/packer/template-debian10--storage/debian10.json
@@ -28,8 +28,8 @@
       "format": "ova",
       "output_directory": "../ova/",
 
-      "iso_url": "../ISO/debian-10.6.0-amd64-netinst.iso",
-      "iso_checksum": "md5:42c43392d108ed8957083843392c794b",
+      "iso_url": "../ISO/debian-10.7.0-amd64-netinst.iso",
+      "iso_checksum": "md5:7227c779619e6c8a0a1b0f55d10c6270",
       "boot_wait": "5s",
       "boot_command": [
         "<esc><wait>",

--- a/packer/template-debian10--vpn/debian10.json
+++ b/packer/template-debian10--vpn/debian10.json
@@ -26,9 +26,9 @@
       "keep_registered": false,
       "format": "ova",
       "output_directory": "../ova/",
-
-      "iso_url": "../ISO/debian-10.6.0-amd64-netinst.iso",
-      "iso_checksum": "md5:42c43392d108ed8957083843392c794b",
+      
+      "iso_url": "../ISO/debian-10.7.0-amd64-netinst.iso",
+      "iso_checksum": "md5:7227c779619e6c8a0a1b0f55d10c6270",
       "boot_wait": "5s",
       "boot_command": [
         "<esc><wait>",


### PR DESCRIPTION
Le lien pour l'iso debian 10.6.0 n'existe plus, je propose une modif pour le passer en 10.7 si cela n'entre pas en conflit avec le reste du projet